### PR TITLE
Include place for analytics on a per-project basis

### DIFF
--- a/_data/projects/lovely-direct.yml
+++ b/_data/projects/lovely-direct.yml
@@ -12,6 +12,8 @@ milestones:
 contact:
 stack: Django, Angular
 team: kat, tyler, diego, ryan, caleb
+analytics_text: Our team's data and analytics live here!
+analytics_links:
 links:
 - https://leasing.livelovely.com
 status:

--- a/_data/projects/rent-la.yml
+++ b/_data/projects/rent-la.yml
@@ -9,6 +9,8 @@ milestones:
 contact:
 stack: Rails, Reactjs
 team: sambone, chris, caleb_w, zain, yong, affan, riley, ashley, casey, serena, george, kaili, allison, ali
+analytics_text:
+analytics_links:
 links:
   - https://sites.google.com/a/rentpath.com/rent-2/home
 status:

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -53,4 +53,22 @@ layout: bare
 	</section>
 	{% endif %}
 
+	{% if proj.analytics_text and proj.analytics_text.length != 0 %}
+	<section class="hub-page-section">
+
+	<h1>Data and Analytics</h1>
+	<ul>
+		<p>
+		{{ proj.analytics_text }}
+		</p>
+	</ul>
+	<ul>
+		{% for link in proj.analytics_links %}
+			<li><a href="{{ link }}">{{ link }}</a></li>
+		{% endfor %}
+	</ul>
+
+	</section>
+	{% endif %}
+
 </div>


### PR DESCRIPTION
Each project yml file should have a place for analytics_text
and analytics_links. It's up to each team's data person to
decide how best to use these for a given team.